### PR TITLE
Use default export for the Template in mdx example

### DIFF
--- a/project/pages/article.mdx
+++ b/project/pages/article.mdx
@@ -1,12 +1,10 @@
 import Template from "components/Template";
 import Button from "components/examples/Button";
 
-<Template>
+default export Template
 
 ## Hello Koen
 
 This is a paragraph.
 
 <Button />
-
-</Template>


### PR DESCRIPTION
This is the [documented][1] way to wrap the contents in a layout component. Otherwise the template gets wrapped in a `<div>` element.

[1]: https://mdxjs.com/syntax#export-default